### PR TITLE
Restyle upload form

### DIFF
--- a/bluetail/templates/bluetail_and_silvereye_shared/base.html
+++ b/bluetail/templates/bluetail_and_silvereye_shared/base.html
@@ -20,7 +20,9 @@
 
     {% include "bluetail_and_silvereye_shared/partials/site-header.html" %}
 
-    {% block content %}{% endblock %}
+    <div class="container-md">
+        {% block content %}{% endblock %}
+    </div>
 
     <div class="site-footer"></div>
 

--- a/cove_project/settings.py
+++ b/cove_project/settings.py
@@ -184,8 +184,9 @@ COVE_CONFIG = {
     "root_list_path": "releases",
     "root_id": "ocid",
     "convert_titles": False,
-    "input_methods": ["upload", "url", "text"],
     "input_template": "silvereye/input.html",
+    # "input_methods": ["upload", "url", "text"],
+    "input_methods": ["upload"],
     "support_email": "data@open-contracting.org",
 }
 

--- a/cove_project/settings.py
+++ b/cove_project/settings.py
@@ -184,8 +184,8 @@ COVE_CONFIG = {
     "root_list_path": "releases",
     "root_id": "ocid",
     "convert_titles": False,
-    "input_template": "cove_ocds/input.html",
     "input_methods": ["upload", "url", "text"],
+    "input_template": "silvereye/input.html",
     "support_email": "data@open-contracting.org",
 }
 

--- a/cove_project/settings.py
+++ b/cove_project/settings.py
@@ -158,7 +158,7 @@ LOGGING["loggers"]["django.security.DisallowedHost"] = {
 
 COVE_CONFIG = {
     "app_name": "cove_ocds",
-    "app_base_template": "cove_ocds/base.html",
+    "app_base_template": "bluetail_and_silvereye_shared/base.html",
     "app_verbose_name": "Open Contracting Data Review Tool",
     "app_strapline": "Review your OCDS data.",
     "schema_name": {

--- a/silvereye/templates/silvereye/input.html
+++ b/silvereye/templates/silvereye/input.html
@@ -1,0 +1,88 @@
+{% extends 'input.html' %}
+{% load bootstrap3 %}
+{% load i18n %}
+
+{% block content %}
+<div class="container-md">
+
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb my-4">
+        <li class="breadcrumb-item active" aria-current="page">Upload</li>
+    </ol>
+  </nav>
+
+  <div id="loading" style="display: none"> <h3> Loading: </h3> <img class="spinner" src="//i1.wp.com/cdnjs.cloudflare.com/ajax/libs/galleriffic/2.0.1/css/loader.gif" alt="spinner" width="30" height="30"> </div>
+  <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+    {% if 'url' in input_methods %}
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingOne" data-toggle="collapse" data-parent="#accordion" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+        <h4 class="panel-title">
+          <a class="accordion-toggle">
+            <span class="glyphicon glyphicon-link" aria-hidden="true"></span>{% trans "Link" %}
+          </a>
+        </h4>
+      </div>
+      <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+        <div class="panel-body">
+          <form method="POST" action="." id="fetchURL">{% csrf_token %}
+              {% bootstrap_form forms.url_form %}
+              {% buttons %}
+                  <button type="submit" class="btn btn-primary">
+                      {% trans 'Submit' %}
+                  </button>
+              {% endbuttons %}
+          </form>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    {% if 'upload' in input_methods %}
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingTwo" data-toggle="collapse" data-parent="#accordion" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
+        <h4 class="panel-title">
+          <a class="accordion-toggle">
+            <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>{% trans "Upload" %}
+          </a>
+        </h4>
+      </div>
+      <div id="collapseTwo" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingTwo">
+        <div class="panel-body">
+          <form method="POST" action="." enctype="multipart/form-data">{% csrf_token %}
+              {% bootstrap_form forms.upload_form %}
+              {% buttons %}
+                  <button type="submit" class="btn btn-primary">
+                      {% trans 'Submit' %}
+                  </button>
+              {% endbuttons %}
+          </form>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    {% if 'text' in input_methods %}
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab" id="headingThree" data-toggle="collapse" data-parent="#accordion" data-target="#collapseThree" aria-expanded="true" aria-controls="collapseThree">
+        <h4 class="panel-title">
+          <a class="accordion-toggle">
+            <span class="glyphicon glyphicon-paste" aria-hidden="true"></span>{% trans "Paste" %}
+          </a>
+        </h4>
+      </div>
+      <div id="collapseThree" class="panel-collapse show-open-if-noscript" role="tabpanel" aria-labelledby="headingThree">
+        <div class="panel-body">
+          <form method="POST" action=".">{% csrf_token %}
+              {% bootstrap_form forms.text_form %}
+              {% buttons %}
+                  <button type="submit" class="btn btn-primary">
+                      {% trans 'Submit' %}
+                  </button>
+              {% endbuttons %}
+          </form>
+        </div>
+      </div>
+    {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This switches the base template over to the bluetail and silvereye shared template.

The other approach that might be worth considering is keeping more of the existing template hierarchy (which might preserve more of the JS behaviour, if we care about that) and adding our stylesheet using the `{% block bootstrap_css %}` bit that the current `cove_ocds/base.html` template has in it. I did briefly explore that approach, but it seemed a bit more involved.

Feedback welcome!

---

![image](https://user-images.githubusercontent.com/22996/88955843-6897e800-d294-11ea-9227-23d15f8abbee.png)

![image](https://user-images.githubusercontent.com/22996/88955885-73eb1380-d294-11ea-98fb-8c050f494dbb.png)
