### PR TITLE
Restore the extrafooterscript block

### DIFF
--- a/bluetail/templates/bluetail_and_silvereye_shared/base.html
+++ b/bluetail/templates/bluetail_and_silvereye_shared/base.html
@@ -26,8 +26,8 @@
     </div>
 
     <div class="site-footer"></div>
-
     <script src="{% static 'jquery/jquery.min.js' %}"></script>
     <script src="{% static 'bootstrap/bootstrap.bundle.min.js' %}"></script>
+        {% block extrafooterscript %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
As this is specified as the app_base_template, overridden by
explore.html in lib-cove-web and then explore_base.html in cove_ocds,
it needs to render this block for templates that extend it to customise