### PR TITLE
Remove bluetail items from site nav

### DIFF
--- a/bluetail/templates/bluetail_and_silvereye_shared/partials/site-header.html
+++ b/bluetail/templates/bluetail_and_silvereye_shared/partials/site-header.html
@@ -11,33 +11,19 @@
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav ml-auto">
-                <li class="nav-item dropdown">
-                    <button class="nav-link btn dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        Tenders
-                    </button>
-                    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                        <h6 class="dropdown-header">Filtered By Dataset</h6>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}">All</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?ocid_prefix=ocds-123abc-">Prototype</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?ocid_prefix=ocds-b5fd17raw-">Contracts Finder unlinked</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?ocid_prefix=ocds-b5fd17suppliermatch-">Contracts Finder with linked suppliers</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?ocid_prefix=ocds-b5fd17bodsmatch-">Contracts Finder with beneficial owners</a>
-
-                        <h6 class="dropdown-header">Filtered By Flag</h6>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?has_flags=true">Any Flag</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?has_flags=true&flag=person_id_matches_cabinet_minister">Beneficial Owner matches Cabinet Minister</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?has_flags=true&flag=company_in_multiple_applications_to_tender">Company linked to multiple applications to a tender</a>
-                        <a class="dropdown-item" href="{% url 'ocds-list' %}?has_flags=true&flag=person_in_multiple_applications_to_tender">Person linked to multiple applications to a tender</a>
-                    </div>
-                </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#">
-                        Spending analysis
+                    <a class="nav-link" href="{% url 'publisher-hub' %}">
+                        Dashboard
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'publisher-hub' %}">
-                        Publisher Hub
+                    <a class="nav-link" href="{% url 'publisher-listing' %}">
+                        Publishers
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'index' %}">
+                        Upload data
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
Bluetail/BODS data isn’t properly integrated into this project yet, so we’re going to hide the Bluetail links for now.

This also gives us space to link directly to the inner parts of the Publisher Hub.

![Screenshot 2020-09-07 at 12 15 10](https://user-images.githubusercontent.com/739624/92382049-dccf7200-f103-11ea-832b-7e5f06eabdff.png)
